### PR TITLE
Add owner, VLOS flag

### DIFF
--- a/utm.yaml
+++ b/utm.yaml
@@ -1040,6 +1040,9 @@ components:
             $ref: '#/components/schemas/Volume4D'
         state:
           $ref: '#/components/schemas/OperationState'
+        vlos:
+          description: If true, this Operation is ensuring deconfliction visually and volumes of other Operations may overlap the volumes of this Operation.
+
 
     Operation:
       description: Full description of a UTM Operation.

--- a/utm.yaml
+++ b/utm.yaml
@@ -655,6 +655,7 @@ components:
         created the Operation but NEVER to other USS instances.
       required:
       - id
+      - owner
       - version
       - time_start
       - time_end
@@ -664,6 +665,14 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/EntityUUID'
+        owner:
+          type: string
+          example: 'uss1'
+          description: |-
+            Created by the DSS based on creating client's ID (via access token).  Used internal
+            to the DSS for restricting mutation and deletion operations to owner.  Used by USSs
+            to reject Operation update notifications originating from a USS that does not own
+            the Operation.
         version:
           description: |-
             Sequential version that the DSS increments every time the Operation changes.  A USS
@@ -842,6 +851,7 @@ components:
         peer-to-peer.
       required:
       - id
+      - owner
       - version
       - time_start
       - time_end
@@ -850,6 +860,14 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/EntityUUID'
+        owner:
+          type: string
+          example: 'uss1'
+          description: |-
+            Created by the DSS based on creating client's ID (via access token).  Used internal
+            to the DSS for restricting mutation and deletion operations to owner.  Used by USSs
+            to reject Constraint update notifications originating from a USS that does not own
+            the Constraint.
         version:
           description: |-
             Sequential version that the DSS increments every time the Constraint changes.  A USS


### PR DESCRIPTION
This PR makes two relatively small updates: a VLOS flag is added to OperationDetails to indicate whether volumes may overlap (VLOS volumes may be overlapped because the operator is providing visual separation), and the `owner` field is re-added to the *References so that USSs can detect an attempt to hijack Subscription updates.  To address this attack, a USS would be expected to note the `owner` of each Operation it was aware of at last contact with the DSS, and then verify that any Operation updates came from the owner of the modified Operation (by checking the `sub`/`client_id` of the access token).  The limits an attack where a malicious USS (or actor within that USS) sends a false Subscription update for an Operation they don't own such that the receiving USS fails to plan around the true Operation.