### PR TITLE
Clean up, and make notifications more RESTful

### DIFF
--- a/utm.yaml
+++ b/utm.yaml
@@ -2,7 +2,7 @@
 openapi: 3.0.2
 info:
   title: UTM API (USS->DSS and USS->USS)
-  version: 0.2.4
+  version: 0.2.6
   description: |-
     Interface definitions for 'Discovery and Synchronization Service' (DSS) and 'UAS Service Supplier (USS).
 

--- a/utm.yaml
+++ b/utm.yaml
@@ -94,8 +94,9 @@ components:
         provided to mutate the airspace.  The EntityOVN is also provided by
         the client whenever that client transmits the full information of the Entity
         (either via GET, or via a subscription notification).
-      allOf:
-      - $ref: '#/components/schemas/UUIDv4'
+      type: string
+      minLength: 16
+      maxLength: 128
       example: '9d158f59-80b7-4c11-9c0c-8a2b4d936b2d'
 
     SubscriptionUUID:

--- a/utm.yaml
+++ b/utm.yaml
@@ -802,7 +802,7 @@ components:
         operation_reference:
           $ref: '#/components/schemas/OperationReference'
 
-    UpdateOperationReferenceResponse:
+    ChangeOperationReferenceResponse:
       description: |-
         Response to a request to create, update, or delete an OperationReference
         in the DSS.
@@ -1436,8 +1436,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpdateOperationReferenceResponse'
-          description: An Operation was created successfully in the DSS.
+                $ref: '#/components/schemas/ChangeOperationReferenceResponse'
+          description: An Operation reference was updated successfully in the DSS.
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeOperationReferenceResponse'
+          description: An Operation reference was created successfully in the DSS.
         "400":
           content:
             application/json:
@@ -1494,7 +1500,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpdateOperationReferenceResponse'
+                $ref: '#/components/schemas/ChangeOperationReferenceResponse'
           description: The specified Operation was successfully removed from the DSS.
         "400":
           content:
@@ -1679,7 +1685,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ChangeConstraintReferenceResponse'
-          description: A Constraint was created successfully in the DSS.
+          description: A Constraint reference was updated successfully in the DSS.
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeConstraintReferenceResponse'
+          description: A Constraint reference was created successfully in the DSS.
         "400":
           content:
             application/json:

--- a/utm.yaml
+++ b/utm.yaml
@@ -1080,9 +1080,14 @@ components:
         Pushed (by a client, not the DSS) directly to clients with subscriptions when
         another client makes a change to airspace within a cell with a subscription.
       required:
+      - operation_id
       - subscriptions
       type: object
       properties:
+        operation_id:
+          description: ID of Operation that has changed.
+          allOf:
+          - $ref: '#/components/schemas/EntityUUID'
         operation:
           description: |-
             Full information about the Operation that has changed.  If this field is omitted,
@@ -1143,9 +1148,14 @@ components:
         Constraint.  Pushed (by a client, not the DSS) directly to clients with subscriptions
         when another client makes a change to airspace within a cell with a subscription.
       required:
+      - constraint_id
       - subscriptions
       type: object
       properties:
+        constraint_id:
+          description: ID of Constraint that has changed.
+          allOf:
+          - $ref: '#/components/schemas/EntityUUID'
         constraint:
           description: |-
             Full information about the Constraint that has changed.  If this field is omitted,
@@ -2147,62 +2157,6 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: The client issued too many requests in a short period of time.
 
-    post:
-      tags:
-      - "Operations"
-      security:
-      - Authority:
-        - utm.strategic_coordination
-      summary: Notify a peer USS of changed Operation details.
-      description: Notify a peer USS directly of changed Operation details (usually as a requirement of previous interactions with the DSS).
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PutOperationDetailsParameters'
-        required: true
-      responses:
-        "204":
-          description: New or updated full Operation information received successfully.
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: |-
-            * One or more parameters were missing or invalid.
-            * The Entity could not be parsed, or contains illegal data.
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: |-
-            Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: |-
-            * The access token was decoded successfully but did not include a scope appropriate to this endpoint.
-            * The client identified in the access token is not the owner of this Entity according to the receiving client's records.
-        "409":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: |-
-            The Entity version specified in this message is lower than
-            a previously-received notification, or identical to a previously-received
-            notification and the Entity is different.
-        "429":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: The client issued too many requests in a short period of time.
-
   /uss/v1/operations/{entityuuid}/telemetry:
     summary: Query detailed information on the position of an off-nominal Operation.
     parameters:
@@ -2257,6 +2211,65 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: UAS is non-conforming and no telemetry data is available.
+        "429":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: The client issued too many requests in a short period of time.
+
+  /uss/v1/operations:
+    summary: A USS's representation of detailed information about Operations.
+    
+    post:
+      tags:
+      - "Operations"
+      security:
+      - Authority:
+        - utm.strategic_coordination
+      summary: Notify a peer USS of changed Operation details.
+      description: Notify a peer USS directly of changed Operation details (usually as a requirement of previous interactions with the DSS).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PutOperationDetailsParameters'
+        required: true
+      responses:
+        "204":
+          description: New or updated full Operation information received successfully.
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: |-
+            * One or more parameters were missing or invalid.
+            * The Entity could not be parsed, or contains illegal data.
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: |-
+            Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: |-
+            * The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+            * The client identified in the access token is not the owner of this Entity according to the receiving client's records.
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: |-
+            The Entity version specified in this message is lower than
+            a previously-received notification, or identical to a previously-received
+            notification and the Entity is different.
         "429":
           content:
             application/json:
@@ -2326,6 +2339,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: The client issued too many requests in a short period of time.
+
+  /uss/v1/constraints:
+    summary: A USS's representation of detailed information about Constraints.
 
     post:
       tags:

--- a/utm.yaml
+++ b/utm.yaml
@@ -400,6 +400,7 @@ components:
           description: |-
             Human-readable message indicating what error occurred and/or why.
           type: string
+          example: 'The error occurred because [...]'
 
     SubscriptionState:
       description: |-

--- a/utm.yaml
+++ b/utm.yaml
@@ -18,12 +18,18 @@ security:
   - utm.constraint_consumption
 
 tags:
-- name: "Operations"
+- name: "Operation references"
   description: |-
-    Endpoints exposed by the DSS for interaction with Operation entities.
-- name: "Constraints"
+    Endpoints exposed by the DSS for interaction with references to Operations.
+- name: "Operation details"
   description: |-
-    Endpoints exposed by the DSS for interaction with Constraint entities.
+    Endpoints exposed by USSs for interaction with details of Operations.
+- name: "Constraint references"
+  description: |-
+    Endpoints exposed by the DSS for interaction with references to Constraints.
+- name: "Constraint details"
+  description: |-
+    Endpoints exposed by USSs for interaction with details of Constraints.
 - name: "Subscriptions"
   description: |-
     Endpoints exposed by the DSS for interaction with Subscription entities.
@@ -1317,7 +1323,7 @@ paths:
               $ref: '#/components/schemas/SearchOperationReferenceParameters'
         required: true
       tags:
-      - "Operations"
+      - "Operation references"
       security:
       - Authority:
         - utm.strategic_coordination
@@ -1374,7 +1380,7 @@ paths:
 
     get:
       tags:
-      - "Operations"
+      - "Operation references"
       security:
       - Authority:
         - utm.strategic_coordination
@@ -1427,7 +1433,7 @@ paths:
               $ref: '#/components/schemas/PutOperationReferenceParameters'
         required: true
       tags:
-      - "Operations"
+      - "Operation references"
       security:
       - Authority:
         - utm.strategic_coordination
@@ -1491,7 +1497,7 @@ paths:
 
     delete:
       tags:
-        - "Operations"
+        - "Operation references"
       security:
         - Authority:
           - utm.strategic_coordination
@@ -1561,7 +1567,7 @@ paths:
               $ref: '#/components/schemas/SearchConstraintReferenceParameters'
         required: true
       tags:
-      - "Constraints"
+      - "Constraint references"
       security:
       - Authority:
         - utm.constraint_management
@@ -1608,7 +1614,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: The client issued too many requests in a short period of time.
 
-  /dss/v1/constraints/{entityuuid}:
+  /dss/v1/constraint_references/{entityuuid}:
     parameters:
     - name: entityuuid
       description: EntityUUID of the Constraint.
@@ -1620,7 +1626,7 @@ paths:
 
     get:
       tags:
-      - "Constraints"
+      - "Constraint references"
       security:
       - Authority:
         - utm.constraint_management
@@ -1675,7 +1681,7 @@ paths:
               $ref: '#/components/schemas/PutConstraintReferenceParameters'
         required: true
       tags:
-      - "Constraints"
+      - "Constraint references"
       security:
       - Authority:
         - utm.constraint_management
@@ -1738,7 +1744,7 @@ paths:
 
     delete:
       tags:
-      - "Constraints"
+      - "Constraint references"
       security:
         - Authority:
           - utm.constraint_management
@@ -2115,7 +2121,7 @@ paths:
   #
 
   /uss/v1/operations/{entityuuid}:
-    summary: Query detailed information of an Operation.
+    summary: Query detailed information of an Operation from a USS.
     parameters:
     - name: entityuuid
       description: EntityUUID for this Operation.
@@ -2126,11 +2132,11 @@ paths:
 
     get:
       tags:
-      - "Operations"
+      - "Operation details"
       security:
       - Authority:
         - utm.strategic_coordination
-      summary: Retrieve the specified Operation details.
+      summary: Retrieve the specified Operation details from a USS.
       responses:
         "200":
           content:
@@ -2172,7 +2178,7 @@ paths:
           description: The client issued too many requests in a short period of time.
 
   /uss/v1/operations/{entityuuid}/telemetry:
-    summary: Query detailed information on the position of an off-nominal Operation.
+    summary: Detailed information on the position of an off-nominal Operation.
     parameters:
     - name: entityuuid
       description: EntityUUID for this Operation.
@@ -2183,11 +2189,11 @@ paths:
 
     get:
       tags:
-      - "Operations"
+      - "Operation details"
       security:
       - Authority:
         - utm.strategic_coordination
-      summary: Query detailed information on the position of an off-nominal Operation.
+      summary: Query detailed information on the position of an off-nominal Operation from a USS.
       responses:
         "200":
           content:
@@ -2237,7 +2243,7 @@ paths:
     
     post:
       tags:
-      - "Operations"
+      - "Operation details"
       security:
       - Authority:
         - utm.strategic_coordination
@@ -2296,7 +2302,7 @@ paths:
   #
 
   /uss/v1/constraints/{entityuuid}:
-    summary: Query detailed information of a Constraint.
+    summary: Query detailed information of a Constraint from a USS.
     parameters:
     - name: entityuuid
       description: EntityUUID of the Constraint.
@@ -2307,12 +2313,12 @@ paths:
 
     get:
       tags:
-      - "Constraints"
+      - "Constraint details"
       security:
       - Authority:
         - utm.strategic_coordination
         - utm.constraint_consumption
-      summary: Retrieve the specified Constraint details.
+      summary: Retrieve the specified Constraint details from a USS.
       description: Retrieve the details of the specified Constraint.
       responses:
         "200":
@@ -2359,7 +2365,7 @@ paths:
 
     post:
       tags:
-      - "Constraints"
+      - "Constraint details"
       security:
       - Authority:
         - utm.strategic_coordination

--- a/utm.yaml
+++ b/utm.yaml
@@ -137,6 +137,14 @@ components:
           enum:
           - RFC3339
 
+    CircleProperties:
+      required:
+      - radius
+      type: object
+      properties:
+        radius:
+          $ref: '#/components/schemas/Radius'
+
     Radius:
       required:
       - value
@@ -319,7 +327,9 @@ components:
 
     Circle:
       description: |-
-        Local extension of the GeoJSON specification to add a circular area defined by a Point/Radius pair. We extend the Properties object to include a 'radius' and 'radius_units' value (see Radius for details).
+        Local extension of the GeoJSON specification to add a circular area defined by a
+        Point/Radius pair. We extend the Properties object to include a 'radius' value (see
+        CircleProperties for details).
       required:
         - type
         - geometry
@@ -342,7 +352,7 @@ components:
             coordinates:
               $ref: '#/components/schemas/Point'
         properties:
-          $ref: '#/components/schemas/Radius'
+          $ref: '#/components/schemas/CircleProperties'
 
 #
 # End of GeoJSON definitions
@@ -365,8 +375,9 @@ components:
           example:
             type: 'Feature'
             properties:
-              value: 300.0
-              units: 'M'
+              radius:
+                value: 300.0
+                units: 'M'
             geometry:
               type: 'Point'
               coordinates: [-121.0123, 56.789]


### PR DESCRIPTION
Per comments from Priya, it is more RESTful to POST to the collection rather than a specific element, so this PR first changes the USS notification receiver endpoint to be consistent with that practice.  Also:

* Make it possible to use something else other than UUIDs for OVNs (for instance, we might want to use a hash to enable exploration of certain details non-repudiation approaches with the DSS) since the VN is Opaque any way (doesn't need to be a UUID)
* Add 201 responses to *Reference creation in the DSS to be more RESTful
* Clean up and harmonize descriptions and organization (DSS vs USS)
* Fix Circle definition (description was inconsistent with updated fields, no data actually specified "radius" in updates)