### PR TITLE
Adjust API to codegen more easily

### DIFF
--- a/utm.yaml
+++ b/utm.yaml
@@ -12,30 +12,30 @@ info:
     Note: Unless otherwise specified, fields specified in a message but not declared in the API shall be ignored.
 
 security:
-- Authority:
-  - utm.strategic_coordination
-  - utm.constraint_management
-  - utm.constraint_consumption
+  - Authority:
+      - utm.strategic_coordination
+      - utm.constraint_management
+      - utm.constraint_consumption
 
 tags:
-- name: "Operation references"
-  description: |-
-    Endpoints exposed by the DSS for interaction with references to Operations.
-- name: "Operation details"
-  description: |-
-    Endpoints exposed by USSs for interaction with details of Operations.
-- name: "Constraint references"
-  description: |-
-    Endpoints exposed by the DSS for interaction with references to Constraints.
-- name: "Constraint details"
-  description: |-
-    Endpoints exposed by USSs for interaction with details of Constraints.
-- name: "Subscriptions"
-  description: |-
-    Endpoints exposed by the DSS for interaction with Subscription entities.
-- name: "Reports"
-  description: |-
-    Endpoints exposed by the DSS for reporting peer DSS issues.
+  - name: "Operation references"
+    description: |-
+      Endpoints exposed by the DSS for interaction with references to Operations.
+  - name: "Operation details"
+    description: |-
+      Endpoints exposed by USSs for interaction with details of Operations.
+  - name: "Constraint references"
+    description: |-
+      Endpoints exposed by the DSS for interaction with references to Constraints.
+  - name: "Constraint details"
+    description: |-
+      Endpoints exposed by USSs for interaction with details of Constraints.
+  - name: "Subscriptions"
+    description: |-
+      Endpoints exposed by the DSS for interaction with Subscription entities.
+  - name: "Reports"
+    description: |-
+      Endpoints exposed by the DSS for reporting peer DSS issues.
 
 #
 #
@@ -87,7 +87,7 @@ components:
         Universally-unique identifier for an Entity communicated through
         the DSS.  Formatted as UUIDv4.
       allOf:
-      - $ref: '#/components/schemas/UUIDv4'
+        - $ref: '#/components/schemas/UUIDv4'
       example: '2f8343be-6482-4d1b-a474-16847e01af1e'
 
     EntityOVN:
@@ -110,7 +110,7 @@ components:
         Universally-unique identifier for a Subscription communicated through
         the DSS.  Formatted as UUIDv4.
       allOf:
-      - $ref: '#/components/schemas/UUIDv4'
+        - $ref: '#/components/schemas/UUIDv4'
       example: '78ea3fe8-71c2-4f5c-9b44-9c02f5563c6f'
 
     Key:
@@ -123,8 +123,8 @@ components:
 
     Time:
       required:
-      - value
-      - format
+        - value
+        - format
       type: object
       properties:
         value:
@@ -135,11 +135,11 @@ components:
         format:
           type: string
           enum:
-          - RFC3339
+            - RFC3339
 
     CircleProperties:
       required:
-      - radius
+        - radius
       type: object
       properties:
         radius:
@@ -147,8 +147,8 @@ components:
 
     Radius:
       required:
-      - value
-      - units
+        - value
+        - units
       type: object
       properties:
         value:
@@ -160,14 +160,14 @@ components:
           type: string
           description: FIXM-compatible units.  Only meters ("M") are acceptable for UTM.
           enum:
-          - M
+            - M
 
     Altitude:
       type: object
       required:
-      - value
-      - reference
-      - units
+        - value
+        - reference
+        - units
       properties:
         value:
           description: |-
@@ -189,7 +189,7 @@ components:
             equivalent to AGL.
           type: string
           enum:
-          - W84
+            - W84
         units:
           description: |-
             The reference quantities used to express the value of altitude. See
@@ -197,7 +197,7 @@ components:
             to allow other options.
           type: string
           enum:
-          - M
+            - M
 
     Latitude:
       description: Degrees of latitude north of the equator, with reference to the WGS84 ellipsoid.
@@ -268,7 +268,7 @@ components:
           description: The type of Geometry. In this case, must be 'Point' per GeoJSON spec.
           type: string
           enum:
-          - Point
+            - Point
         coordinates:
           $ref: '#/components/schemas/LonLatPair'
 
@@ -289,7 +289,7 @@ components:
             currently.
           type: string
           enum:
-          - Polygon
+            - Polygon
         coordinates:
           type: array
           description: >-
@@ -340,7 +340,7 @@ components:
           description: The type of Geometry. In this case, must be 'Feature' per GeoJSON spec.
           type: string
           enum:
-          - Feature
+            - Feature
         geometry:
           type: object
           properties:
@@ -348,7 +348,7 @@ components:
               description: The type of Geometry. Must be Point.
               type: string
               enum:
-              - Point
+                - Point
             coordinates:
               $ref: '#/components/schemas/Point'
         properties:
@@ -362,15 +362,15 @@ components:
       description: |-
         A three-dimensional geographic volume consisting of a vertically-extruded shape.
       required:
-      - area
-      - altitude_lower
-      - altitude_upper
+        - area
+        - altitude_lower
+        - altitude_upper
       type: object
       properties:
         area:
           oneOf:
-          - $ref: '#/components/schemas/Polygon'
-          - $ref: '#/components/schemas/Circle'
+            - $ref: '#/components/schemas/Polygon'
+            - $ref: '#/components/schemas/Circle'
           description: A geographic shape on the surface of the earth.
           example:
             type: 'Feature'
@@ -384,16 +384,16 @@ components:
         altitude_lower:
           description: Minimum bounding altitude of this volume.
           allOf:
-          - $ref: '#/components/schemas/Altitude'
+            - $ref: '#/components/schemas/Altitude'
         altitude_upper:
           description: Maximum bounding altitude of this volume.
           allOf:
-          - $ref: '#/components/schemas/Altitude'
+            - $ref: '#/components/schemas/Altitude'
 
     Volume4D:
       description: Contiguous block of geographic spacetime.
       required:
-      - volume
+        - volume
       type: object
       properties:
         volume:
@@ -401,11 +401,11 @@ components:
         time_start:
           description: Beginning time of this volume.
           allOf:
-          - $ref: '#/components/schemas/Time'
+            - $ref: '#/components/schemas/Time'
         time_end:
           description: End time of this volume.
           allOf:
-          - $ref: '#/components/schemas/Time'
+            - $ref: '#/components/schemas/Time'
 
     ErrorResponse:
       description: |-
@@ -423,8 +423,8 @@ components:
       description: |-
         State of Subscription which is causing a notification to be sent.
       required:
-      - subscription_id
-      - notification_index
+        - subscription_id
+        - notification_index
       type: object
       properties:
         subscription_id:
@@ -439,8 +439,8 @@ components:
         to send a notification to the specified USS according to the change made to the
         airspace.
       required:
-      - subscriptions
-      - uss_base_url
+        - subscriptions
+        - uss_base_url
       type: object
       properties:
         subscriptions:
@@ -457,10 +457,10 @@ components:
         Specification of a geographic area that a client is interested
         in on an ongoing basis (e.g., "planning area").
       required:
-      - id
-      - version
-      - notification_index
-      - uss_base_url
+        - id
+        - version
+        - notification_index
+        - uss_base_url
       type: object
       properties:
         id:
@@ -481,13 +481,13 @@ components:
             If set, this subscription will not receive notifications involving airspace changes
             entirely before this time.
           allOf:
-          - $ref: '#/components/schemas/Time'
+            - $ref: '#/components/schemas/Time'
         time_end:
           description: |-
             If set, this subscription will not receive notifications involving airspace changes
             entirely after this time.
           allOf:
-          - $ref: '#/components/schemas/Time'
+            - $ref: '#/components/schemas/Time'
         uss_base_url:
           $ref: '#/components/schemas/SubscriptionUssBaseURL'
         notify_for_operations:
@@ -531,7 +531,7 @@ components:
     SearchSubscriptionsResponse:
       description: Response to DSS query for subscriptions in a particular geographic area.
       required:
-      - subscriptions
+        - subscriptions
       type: object
       properties:
         subscriptions:
@@ -544,7 +544,7 @@ components:
     GetSubscriptionResponse:
       description: Response to DSS request for the subscription with the given id.
       required:
-      - subscription
+        - subscription
       type: object
       properties:
         subscription:
@@ -554,9 +554,9 @@ components:
       description: |-
         Parameters for a request to create/update a subscription in the DSS.
       required:
-      - extents
-      - old_version
-      - uss_base_url
+        - extents
+        - old_version
+        - uss_base_url
       type: object
       properties:
         extents:
@@ -587,13 +587,13 @@ components:
         The base URL of a USS implementation of the parts of the USS-USS API necessary for
         receiving the notifications requested by this Subscription.
       allOf:
-      - $ref: '#/components/schemas/UssBaseURL'
+        - $ref: '#/components/schemas/UssBaseURL'
 
     PutSubscriptionResponse:
       description: |-
         Response for a request to create or update a subscription.
       required:
-      - subscription
+        - subscription
       type: object
       properties:
         subscription:
@@ -619,7 +619,7 @@ components:
     DeleteSubscriptionResponse:
       description: Response for a successful request to delete an Subscription.
       required:
-      - subscription
+        - subscription
       type: object
       properties:
         subscription:
@@ -673,13 +673,13 @@ components:
         of a USS to query for details.  Note: 'OVN' is returned ONLY to the USS that
         created the Operation but NEVER to other USS instances.
       required:
-      - id
-      - owner
-      - version
-      - time_start
-      - time_end
-      - uss_base_url
-      - subscription_id
+        - id
+        - owner
+        - version
+        - time_start
+        - time_end
+        - uss_base_url
+        - subscription_id
       type: object
       properties:
         id:
@@ -708,15 +708,15 @@ components:
             OperationReference is not owned by the USS retrieving or providing it (instead, the
             USS must obtain the OVN from the details retrieved from the owning USS).
           allOf:
-          - $ref: '#/components/schemas/EntityOVN'
+            - $ref: '#/components/schemas/EntityOVN'
         time_start:
           description: Beginning time of Operation.
           allOf:
-          - $ref: '#/components/schemas/Time'
+            - $ref: '#/components/schemas/Time'
         time_end:
           description: End time of Operation.
           allOf:
-          - $ref: '#/components/schemas/Time'
+            - $ref: '#/components/schemas/Time'
         uss_base_url:
           $ref: '#/components/schemas/OperationUssBaseURL'
         subscription_id:
@@ -724,7 +724,7 @@ components:
             The ID of the Subscription that is ensuring the Operation owner receives relevant
             airspace updates.
           allOf:
-          - $ref: '#/components/schemas/SubscriptionUUID'
+            - $ref: '#/components/schemas/SubscriptionUUID'
 
     OperationUssBaseURL:
       description: |-
@@ -732,7 +732,7 @@ components:
         providing the details of this Operation, and telemetry during non-conformance or contingency,
         if applicable.
       allOf:
-      - $ref: '#/components/schemas/UssBaseURL'
+        - $ref: '#/components/schemas/UssBaseURL'
 
     PutOperationReferenceParameters:
       description: |-
@@ -741,10 +741,10 @@ components:
         this can be overridden by providing the (optional) 'subscription_id' to use.
         Note: The implicit subscription is managed by the DSS, not the USS.
       required:
-      - extents
-      - old_version
-      - state
-      - uss_base_url
+        - extents
+        - old_version
+        - state
+        - uss_base_url
       type: object
       properties:
         extents:
@@ -772,7 +772,7 @@ components:
             Constraints, which is determined by whether the Subscription associated with this Operation
             triggers notifications for Constraints.
           allOf:
-          - $ref: '#/components/schemas/Key'
+            - $ref: '#/components/schemas/Key'
         state:
           $ref: '#/components/schemas/OperationState'
         uss_base_url:
@@ -785,7 +785,7 @@ components:
             for the Operation.  The Subscription specified by this ID must cover at least the area over
             which this Operation is conducted, and it must provide notifications for Operations.
           allOf:
-          - $ref: '#/components/schemas/EntityUUID'
+            - $ref: '#/components/schemas/EntityUUID'
         new_subscription:
           description: |-
             If an existing Subscription is not specified in `subscription_id`, then this field must be
@@ -793,14 +793,14 @@ components:
             associated with this Operation, and will generally be deleted automatically upon the
             deletion of this Operation.
           allOf:
-          - $ref: '#/components/schemas/ImplicitSubscriptionParameters'
+            - $ref: '#/components/schemas/ImplicitSubscriptionParameters'
 
     ImplicitSubscriptionParameters:
       description: |-
         Information necessary to create a Subscription to serve a single Operation's notification needs.
       type: object
       required:
-      - uss_base_url
+        - uss_base_url
       properties:
         uss_base_url:
           description: |-
@@ -808,7 +808,7 @@ components:
             receiving the notifications that the Operation must be aware of.  This includes, at least,
             notifications for relevant changes in Operations.
           allOf:
-          - $ref: '#/components/schemas/SubscriptionUssBaseURL'
+            - $ref: '#/components/schemas/SubscriptionUssBaseURL'
         notify_for_constraints:
           description: |-
             True if this Operation's Subscription should trigger notifications when Constraints change.  Otherwise, changes in Constraints should not trigger notifications.
@@ -819,7 +819,7 @@ components:
       description: |-
         Response to DSS request for the OperationReference with the given ID.
       required:
-      - operation_reference
+        - operation_reference
       type: object
       properties:
         operation_reference:
@@ -830,8 +830,8 @@ components:
         Response to a request to create, update, or delete an OperationReference
         in the DSS.
       required:
-      - subscribers
-      - operation_reference
+        - subscribers
+        - operation_reference
       type: object
       properties:
         subscribers:
@@ -858,7 +858,7 @@ components:
     SearchOperationReferenceResponse:
       description: Response to DSS query for OperationReferences in an area of interest.
       required:
-      - operation_references
+        - operation_references
       type: object
       properties:
         operation_references:
@@ -874,12 +874,12 @@ components:
         these references and clients must exchange details and additional information
         peer-to-peer.
       required:
-      - id
-      - owner
-      - version
-      - time_start
-      - time_end
-      - uss_base_url
+        - id
+        - owner
+        - version
+        - time_start
+        - time_end
+        - uss_base_url
       type: object
       properties:
         id:
@@ -908,7 +908,7 @@ components:
             ConstraintReference is not owned by the USS retrieving or providing it (instead, the
             USS must obtain the OVN from the details retrieved from the owning USS).
           allOf:
-          - $ref: '#/components/schemas/EntityOVN'
+            - $ref: '#/components/schemas/EntityOVN'
         time_start:
           $ref: '#/components/schemas/Time'
         time_end:
@@ -921,15 +921,15 @@ components:
         The base URL of a USS implementation that implements the parts of the USS-USS API necessary for
         providing the details of this Constraint.
       allOf:
-      - $ref: '#/components/schemas/UssBaseURL'
+        - $ref: '#/components/schemas/UssBaseURL'
 
     PutConstraintReferenceParameters:
       description: Parameters for a request to create/update a ConstraintReference in the
         DSS.
       required:
-      - extents
-      - old_version
-      - uss_base_url
+        - extents
+        - old_version
+        - uss_base_url
       type: object
       properties:
         extents:
@@ -954,7 +954,7 @@ components:
       description: Response to DSS request for the ConstraintReference with the given
         ID.
       required:
-      - constraint_reference
+        - constraint_reference
       type: object
       properties:
         constraint_reference:
@@ -964,7 +964,7 @@ components:
       description: Response to a request to create, update, or delete a ConstraintReference.
         in the DSS.
       required:
-      - subscribers
+        - subscribers
       type: object
       properties:
         subscribers:
@@ -990,7 +990,7 @@ components:
     SearchConstraintReferencesResponse:
       description: Response to DSS query for ConstraintReferences in an area of interest.
       required:
-      - constraint_references
+        - constraint_references
       type: object
       properties:
         constraint_references:
@@ -1061,24 +1061,24 @@ components:
         time_request:
           description: The time at which the problematic request was initiated.
           allOf:
-          - $ref: '#/components/schemas/Time'
+            - $ref: '#/components/schemas/Time'
         time_response:
           description: The time at which the problematic response was received.
           allOf:
-          - $ref: '#/components/schemas/Time'
+            - $ref: '#/components/schemas/Time'
         report_id:
           description: ID assigned by the server receiving the report.  Not populated when submitting a report.
           type: string
           maxLength: 128
 
-#
-# USS-USS schema components
-#
+    #
+    # USS-USS schema components
+    #
     OperationDetails:
       description: |-
         Details of a UTM Operation. Note that this data is not stored in the DSS; only with the clients.
       required:
-      - volumes
+        - volumes
       type: object
       properties:
         volumes:
@@ -1099,8 +1099,8 @@ components:
     Operation:
       description: Full description of a UTM Operation.
       required:
-      - reference
-      - details
+        - reference
+        - details
       type: object
       properties:
         reference:
@@ -1114,14 +1114,14 @@ components:
         Pushed (by a client, not the DSS) directly to clients with subscriptions when
         another client makes a change to airspace within a cell with a subscription.
       required:
-      - operation_id
-      - subscriptions
+        - operation_id
+        - subscriptions
       type: object
       properties:
         operation_id:
           description: ID of Operation that has changed.
           allOf:
-          - $ref: '#/components/schemas/EntityUUID'
+            - $ref: '#/components/schemas/EntityUUID'
         operation:
           description: |-
             Full information about the Operation that has changed.  If this field is omitted,
@@ -1129,7 +1129,7 @@ components:
             an updated Operation by examining the `version` field.  The `ovn` field in the
             nested `reference` must be populated.
           allOf:
-          - $ref: '#/components/schemas/Operation'
+            - $ref: '#/components/schemas/Operation'
         subscriptions:
           type: array
           description: Subscription(s) prompting this notification.
@@ -1140,7 +1140,7 @@ components:
     GetOperationDetailsResponse:
       description: Response to peer request for the details of Operation with the given ID.
       required:
-      - operation
+        - operation
       type: object
       properties:
         operation:
@@ -1150,7 +1150,7 @@ components:
       description: Details of a UTM Constraint. Note that this data is
         not stored in the DSS; only with the clients.
       required:
-      - volumes
+        - volumes
       type: object
       properties:
         volumes:
@@ -1168,8 +1168,8 @@ components:
     Constraint:
       description: Full specification of a UTM Constraint.
       required:
-      - reference
-      - details
+        - reference
+        - details
       type: object
       properties:
         reference:
@@ -1182,14 +1182,14 @@ components:
         Constraint.  Pushed (by a client, not the DSS) directly to clients with subscriptions
         when another client makes a change to airspace within a cell with a subscription.
       required:
-      - constraint_id
-      - subscriptions
+        - constraint_id
+        - subscriptions
       type: object
       properties:
         constraint_id:
           description: ID of Constraint that has changed.
           allOf:
-          - $ref: '#/components/schemas/EntityUUID'
+            - $ref: '#/components/schemas/EntityUUID'
         constraint:
           description: |-
             Full information about the Constraint that has changed.  If this field is omitted,
@@ -1197,7 +1197,7 @@ components:
             an updated Constraint by examining the `version` field.  The `ovn` field in the
             nested `reference` must be populated.
           allOf:
-          - $ref: '#/components/schemas/Constraint'
+            - $ref: '#/components/schemas/Constraint'
         subscriptions:
           description: Subscription(s) prompting this notification.
           type: array
@@ -1209,7 +1209,7 @@ components:
       description: |-
         Response to peer request for the details of Operation with the given ID.
       required:
-      - constraint
+        - constraint
       type: object
       properties:
         constraint:
@@ -1218,7 +1218,7 @@ components:
     GetOperationTelemetryResponse:
       description: Response to a peer request for telemetry of an off-nominal Operation.
       required:
-      - telemetry
+        - telemetry
       type: object
       properties:
         telemetry:
@@ -1227,8 +1227,8 @@ components:
     VehicleTelemetry:
       description: Vehicle position, altitude, and velocity.
       required:
-      - id
-      - time_measured
+        - id
+        - time_measured
       type: object
       properties:
         id:
@@ -1246,14 +1246,14 @@ components:
         This is the GVA enumeration from ADS-B, plus some finer values for UAS.
       type: string
       enum:
-      - VAUnknown
-      - VA150mPlus
-      - VA150m
-      - VA45m
-      - VA25m
-      - VA10m
-      - VA3m
-      - VA1m
+        - VAUnknown
+        - VA150mPlus
+        - VA150m
+        - VA45m
+        - VA25m
+        - VA10m
+        - VA3m
+        - VA1m
 
     PositionAccuracyHorizontal:
       description: |-
@@ -1261,20 +1261,20 @@ components:
         This is the NACp enumeration from ADS-B, plus 1m for a more complete range for UAS.
       type: string
       enum:
-      - HAUnknown
-      - HA10NMPlus
-      - HA10NM
-      - HA4NM
-      - HA2NM
-      - HA1NM
-      - HA05NM
-      - HA03NM
-      - HA01NM
-      - HA005NM
-      - HA30m
-      - HA10m
-      - HA3m
-      - HA1m
+        - HAUnknown
+        - HA10NMPlus
+        - HA10NM
+        - HA4NM
+        - HA2NM
+        - HA1NM
+        - HA05NM
+        - HA03NM
+        - HA01NM
+        - HA005NM
+        - HA30m
+        - HA10m
+        - HA3m
+        - HA1m
 
     Position:
       description: |-
@@ -1301,8 +1301,8 @@ components:
 
     Velocity:
       required:
-      - speed
-      - units_speed
+        - speed
+        - units_speed
       type: object
       properties:
         speed:
@@ -1314,7 +1314,7 @@ components:
         units_speed:
           type: string
           enum:
-          - MetersSecond
+            - MetersSecond
         track:
           format: float
           type: number
@@ -1340,10 +1340,10 @@ paths:
               $ref: '#/components/schemas/SearchOperationReferenceParameters'
         required: true
       tags:
-      - "Operation references"
+        - "Operation references"
       security:
-      - Authority:
-        - utm.strategic_coordination
+        - Authority:
+            - utm.strategic_coordination
       summary: Retrieve all Operation references in the specified area/volume/time from the DSS.
       responses:
         "200":
@@ -1388,19 +1388,19 @@ paths:
   /dss/v1/operation_references/{entityuuid}:
     summary: CRUD endpoint for a specified Operation reference in the DSS.
     parameters:
-    - name: entityuuid
-      description: EntityUUID of the Operation.
-      schema:
-        $ref: '#/components/schemas/EntityUUID'
-      in: path
-      required: true
+      - name: entityuuid
+        description: EntityUUID of the Operation.
+        schema:
+          $ref: '#/components/schemas/EntityUUID'
+        in: path
+        required: true
 
     get:
       tags:
-      - "Operation references"
+        - "Operation references"
       security:
-      - Authority:
-        - utm.strategic_coordination
+        - Authority:
+            - utm.strategic_coordination
       summary: Retrieve the specified Operation reference from the DSS.
       responses:
         "200":
@@ -1450,10 +1450,10 @@ paths:
               $ref: '#/components/schemas/PutOperationReferenceParameters'
         required: true
       tags:
-      - "Operation references"
+        - "Operation references"
       security:
-      - Authority:
-        - utm.strategic_coordination
+        - Authority:
+            - utm.strategic_coordination
       summary: Create/Update the specified Operation reference in the DSS.
       responses:
         "200":
@@ -1517,7 +1517,7 @@ paths:
         - "Operation references"
       security:
         - Authority:
-          - utm.strategic_coordination
+            - utm.strategic_coordination
       summary: Remove the specified Operation reference from the DSS.
       responses:
         "200":
@@ -1532,22 +1532,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: |-
-              * One or more input parameters were missing or invalid.
-              * The request attempted to mutate the Operation in a disallowed way.
+            * One or more input parameters were missing or invalid.
+            * The request attempted to mutate the Operation in a disallowed way.
         "401":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Bearer access token was not provided in Authorization header,
-              token could not be decoded, or token was invalid.
+            token could not be decoded, or token was invalid.
         "403":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: The access token was decoded successfully but did not include
-              a scope appropriate to this endpoint.
+            a scope appropriate to this endpoint.
         "404":
           content:
             application/json:
@@ -1560,7 +1560,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: |-
-              * Despite repeated attempts, the DSS was unable to complete the update because of other simultaneous changes.
+            * Despite repeated attempts, the DSS was unable to complete the update because of other simultaneous changes.
         "429":
           content:
             application/json:
@@ -1584,12 +1584,12 @@ paths:
               $ref: '#/components/schemas/SearchConstraintReferenceParameters'
         required: true
       tags:
-      - "Constraint references"
+        - "Constraint references"
       security:
-      - Authority:
-        - utm.constraint_management
-        - utm.constraint_consumption
-        - utm.strategic_coordination
+        - Authority:
+            - utm.constraint_management
+            - utm.constraint_consumption
+            - utm.strategic_coordination
       summary: Retrieve all Constraints references in the specified area/volume from the DSS.
       responses:
         "200":
@@ -1633,22 +1633,22 @@ paths:
 
   /dss/v1/constraint_references/{entityuuid}:
     parameters:
-    - name: entityuuid
-      description: EntityUUID of the Constraint.
-      schema:
-        $ref: '#/components/schemas/EntityUUID'
-      in: path
-      required: true
+      - name: entityuuid
+        description: EntityUUID of the Constraint.
+        schema:
+          $ref: '#/components/schemas/EntityUUID'
+        in: path
+        required: true
     summary: CRUD endpoint for a specified Constraint reference in the DSS.
 
     get:
       tags:
-      - "Constraint references"
+        - "Constraint references"
       security:
-      - Authority:
-        - utm.constraint_management
-        - utm.constraint_consumption
-        - utm.strategic_coordination
+        - Authority:
+            - utm.constraint_management
+            - utm.constraint_consumption
+            - utm.strategic_coordination
       summary: Retrieve the specified Constraint reference from the DSS.
       responses:
         "200":
@@ -1698,10 +1698,10 @@ paths:
               $ref: '#/components/schemas/PutConstraintReferenceParameters'
         required: true
       tags:
-      - "Constraint references"
+        - "Constraint references"
       security:
-      - Authority:
-        - utm.constraint_management
+        - Authority:
+            - utm.constraint_management
       summary: Create/Update the specified Constraint reference in the DSS.
       responses:
         "200":
@@ -1761,10 +1761,10 @@ paths:
 
     delete:
       tags:
-      - "Constraint references"
+        - "Constraint references"
       security:
         - Authority:
-          - utm.constraint_management
+            - utm.constraint_management
       summary: Delete the specified Constraint reference from the DSS.
       responses:
         "200":
@@ -1779,22 +1779,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: |-
-              * One or more input parameters were missing or invalid.
-              * The request attempted to mutate the Constraint in a disallowed way.
+            * One or more input parameters were missing or invalid.
+            * The request attempted to mutate the Constraint in a disallowed way.
         "401":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Bearer access token was not provided in Authorization header,
-              token could not be decoded, or token was invalid.
+            token could not be decoded, or token was invalid.
         "403":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: The access token was decoded successfully but did not include
-              a scope appropriate to this endpoint.
+            a scope appropriate to this endpoint.
         "404":
           content:
             application/json:
@@ -1807,7 +1807,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: |-
-              * Despite repeated attempts, the DSS was unable to complete the update because of other simultaneous changes.
+            * Despite repeated attempts, the DSS was unable to complete the update because of other simultaneous changes.
         "429":
           content:
             application/json:
@@ -1830,11 +1830,11 @@ paths:
               $ref: '#/components/schemas/SearchSubscriptionParameters'
         required: true
       tags:
-      - "Subscriptions"
+        - "Subscriptions"
       security:
-      - Authority:
-        - utm.constraint_consumption
-        - utm.strategic_coordination
+        - Authority:
+            - utm.constraint_consumption
+            - utm.strategic_coordination
       description: |-
         Retrieve Subscriptions intersecting an area of interest.  Subscription
         notifications are only triggered by (and contain full information of) changes to,
@@ -1892,20 +1892,20 @@ paths:
   /dss/v1/subscriptions/{subscriptionid}:
     summary: Create/Update a specific Subscription in the DSS.
     parameters:
-    - name: subscriptionid
-      description: SubscriptionUUID of the subscription of interest.
-      schema:
-        $ref: '#/components/schemas/SubscriptionUUID'
-      in: path
-      required: true
+      - name: subscriptionid
+        description: SubscriptionUUID of the subscription of interest.
+        schema:
+          $ref: '#/components/schemas/SubscriptionUUID'
+        in: path
+        required: true
 
     get:
       tags:
-      - "Subscriptions"
+        - "Subscriptions"
       security:
-      - Authority:
-        - utm.constraint_consumption
-        - utm.strategic_coordination
+        - Authority:
+            - utm.constraint_consumption
+            - utm.strategic_coordination
       summary: Retrieve the specified Subscription from the DSS.
       description: |-
         Retrieve a specific subscription.
@@ -1951,9 +1951,9 @@ paths:
 
     put:
       security:
-      - Authority:
-        - utm.constraint_consumption
-        - utm.strategic_coordination
+        - Authority:
+            - utm.constraint_consumption
+            - utm.strategic_coordination
       summary: Create/Update the specified Subscription in the DSS.
       description: |-
         Create or update a subscription.
@@ -1966,7 +1966,7 @@ paths:
               $ref: '#/components/schemas/PutSubscriptionParameters'
         required: true
       tags:
-      - "Subscriptions"
+        - "Subscriptions"
       responses:
         "200":
           content:
@@ -2019,17 +2019,17 @@ paths:
             is necessary to bound performance requirements for DSS instances and would
             likely be hit by, e.g., a large remote ID display provider that created
             a Subscription for each of their display client users' views.
-            
+
             Alternately, the client may have issued too many requests within a small
             period of time.
 
     delete:
       tags:
-      - "Subscriptions"
+        - "Subscriptions"
       security:
         - Authority:
-          - utm.constraint_consumption
-          - utm.strategic_coordination
+            - utm.constraint_consumption
+            - utm.strategic_coordination
       summary: Remove the specified Subscription from the DSS.
       responses:
         "200":
@@ -2050,14 +2050,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Bearer access token was not provided in Authorization header,
-              token could not be decoded, or token was invalid.
+            token could not be decoded, or token was invalid.
         "403":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: The access token was decoded successfully but did not include
-              a scope appropriate to this endpoint.
+            a scope appropriate to this endpoint.
         "404":
           content:
             application/json:
@@ -2071,19 +2071,19 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: The client issued too many requests in a short period of time.
 
-#
-# DSS Endpoint: REPORT
-#
+  #
+  # DSS Endpoint: REPORT
+  #
 
   /dss/v1/reports:
     summary: Error reports of potential operational issues relevant to DSSs.
 
     post:
       security:
-      - Authority:
-        - utm.constraint_management
-        - utm.constraint_consumption
-        - utm.strategic_coordination
+        - Authority:
+            - utm.constraint_management
+            - utm.constraint_consumption
+            - utm.strategic_coordination
       summary: Report information about communication issues to a DSS.
       description: Report issues to a DSS. Data sent to this endpoint is archived.
       requestBody:
@@ -2093,7 +2093,7 @@ paths:
               $ref: '#/components/schemas/ErrorReport'
         required: true
       tags:
-      - "Reports"
+        - "Reports"
       responses:
         "201":
           description: A new Report was created successfully (and archived).
@@ -2137,19 +2137,19 @@ paths:
   /uss/v1/operations/{entityuuid}:
     summary: Query detailed information of an Operation from a USS.
     parameters:
-    - name: entityuuid
-      description: EntityUUID for this Operation.
-      schema:
-        $ref: '#/components/schemas/EntityUUID'
-      in: path
-      required: true
+      - name: entityuuid
+        description: EntityUUID for this Operation.
+        schema:
+          $ref: '#/components/schemas/EntityUUID'
+        in: path
+        required: true
 
     get:
       tags:
-      - "Operation details"
+        - "Operation details"
       security:
-      - Authority:
-        - utm.strategic_coordination
+        - Authority:
+            - utm.strategic_coordination
       summary: Retrieve the specified Operation details from a USS.
       responses:
         "200":
@@ -2194,19 +2194,19 @@ paths:
   /uss/v1/operations/{entityuuid}/telemetry:
     summary: Detailed information on the position of an off-nominal Operation.
     parameters:
-    - name: entityuuid
-      description: EntityUUID for this Operation.
-      schema:
-        $ref: '#/components/schemas/EntityUUID'
-      in: path
-      required: true
+      - name: entityuuid
+        description: EntityUUID for this Operation.
+        schema:
+          $ref: '#/components/schemas/EntityUUID'
+        in: path
+        required: true
 
     get:
       tags:
-      - "Operation details"
+        - "Operation details"
       security:
-      - Authority:
-        - utm.strategic_coordination
+        - Authority:
+            - utm.strategic_coordination
       summary: Query detailed information on the position of an off-nominal Operation from a USS.
       responses:
         "200":
@@ -2254,13 +2254,13 @@ paths:
 
   /uss/v1/operations:
     summary: A USS's representation of detailed information about Operations.
-    
+
     post:
       tags:
-      - "Operation details"
+        - "Operation details"
       security:
-      - Authority:
-        - utm.strategic_coordination
+        - Authority:
+            - utm.strategic_coordination
       summary: Notify a peer USS of changed Operation details.
       description: Notify a peer USS directly of changed Operation details (usually as a requirement of previous interactions with the DSS).
       requestBody:
@@ -2318,20 +2318,20 @@ paths:
   /uss/v1/constraints/{entityuuid}:
     summary: Query detailed information of a Constraint from a USS.
     parameters:
-    - name: entityuuid
-      description: EntityUUID of the Constraint.
-      schema:
-        $ref: '#/components/schemas/EntityUUID'
-      in: path
-      required: true
+      - name: entityuuid
+        description: EntityUUID of the Constraint.
+        schema:
+          $ref: '#/components/schemas/EntityUUID'
+        in: path
+        required: true
 
     get:
       tags:
-      - "Constraint details"
+        - "Constraint details"
       security:
-      - Authority:
-        - utm.strategic_coordination
-        - utm.constraint_consumption
+        - Authority:
+            - utm.strategic_coordination
+            - utm.constraint_consumption
       summary: Retrieve the specified Constraint details from a USS.
       description: Retrieve the details of the specified Constraint.
       responses:
@@ -2379,11 +2379,11 @@ paths:
 
     post:
       tags:
-      - "Constraint details"
+        - "Constraint details"
       security:
-      - Authority:
-        - utm.strategic_coordination
-        - utm.constraint_consumption
+        - Authority:
+            - utm.strategic_coordination
+            - utm.constraint_consumption
       summary: Notify a peer USS of changed Constraint details.
       description: Notify a peer USS directly of changed Constraint details (usually as a requirement of previous interactions with the DSS).
       requestBody:
@@ -2445,9 +2445,9 @@ paths:
         - "Reports"
       security:
         - Authority:
-          - utm.strategic_coordination
-          - utm.constraint_consumption
-          - utm.constraint_management
+            - utm.strategic_coordination
+            - utm.constraint_consumption
+            - utm.constraint_management
       summary: Notify USS of an error encountered that might otherwise go unnoticed.
       description: Endpoint to provide feedback (errors, etc.) that might otherwise go unnoticed by this USS.  This endpoint is used for all feedback related to Operations and Constraints.
       requestBody:

--- a/utm.yaml
+++ b/utm.yaml
@@ -36,6 +36,11 @@ tags:
   - name: "Reports"
     description: |-
       Endpoints exposed by the DSS for reporting peer DSS issues.
+  - name: dss
+    description: Endpoints exposed by the DSS server.
+  - name: p2p_utm
+    description: Endpoints exposed by UTM USSs for peer-peer communication.
+
 
 #
 #
@@ -86,7 +91,7 @@ components:
       description: |-
         Universally-unique identifier for an Entity communicated through
         the DSS.  Formatted as UUIDv4.
-      allOf:
+      anyOf:
         - $ref: '#/components/schemas/UUIDv4'
       example: '2f8343be-6482-4d1b-a474-16847e01af1e'
 
@@ -109,7 +114,7 @@ components:
       description: |-
         Universally-unique identifier for a Subscription communicated through
         the DSS.  Formatted as UUIDv4.
-      allOf:
+      anyOf:
         - $ref: '#/components/schemas/UUIDv4'
       example: '78ea3fe8-71c2-4f5c-9b44-9c02f5563c6f'
 
@@ -177,9 +182,9 @@ components:
             these bounds should be re-evaluated.
           type: number
           format: double
-          minimum: -8000.0
+          minimum: -8000
           exclusiveMinimum: false
-          maximum: 100000.0
+          maximum: 100000
           exclusiveMaximum: false
         reference:
           description: |-
@@ -211,13 +216,25 @@ components:
 
     Longitude:
       description: Degrees of longitude east of the Prime Meridian, with reference to the WGS84 ellipsoid.
-      maximum: -180
+      minimum: -180
       exclusiveMaximum: false
-      minimum: 180
+      maximum: 180
       exclusiveMinimum: false
       type: number
       format: double
       example: -118.456
+
+    LongitudeOrLatitude:
+      description: |-
+        Degrees of longitude east of the Prime Meridian or degrees of latitude north of the equator, with reference to
+        the WGS84 ellipsoid.
+      minimum: -180
+      exclusiveMinimum: false
+      maximum: 180
+      exclusiveMaximum: false
+      type: number
+      format: double
+      example: 12.34
 
     LonLatPair:
       description: Longitude/Latitude pair (in that order) used for specifying geographical vertex. Specified as an array. Order is important!
@@ -225,9 +242,7 @@ components:
       maxItems: 2
       minItems: 2
       items:
-        oneOf:
-          - $ref: '#/components/schemas/Longitude'
-          - $ref: '#/components/schemas/Latitude'
+        $ref: '#/components/schemas/LongitudeOrLatitude'
       example: [-122.106325, 47.660898]
 
 #
@@ -360,34 +375,28 @@ components:
 
     Volume3D:
       description: |-
-        A three-dimensional geographic volume consisting of a vertically-extruded shape.
+        A three-dimensional geographic volume consisting of a vertically-extruded shape.  Exactly one of
+        `outline_polygon` or `outline_circle` must be specified.
       required:
-        - area
         - altitude_lower
         - altitude_upper
       type: object
       properties:
-        area:
-          oneOf:
-            - $ref: '#/components/schemas/Polygon'
+        outline_circle:
+          anyOf:
             - $ref: '#/components/schemas/Circle'
-          description: A geographic shape on the surface of the earth.
-          example:
-            type: 'Feature'
-            properties:
-              radius:
-                value: 300.0
-                units: 'M'
-            geometry:
-              type: 'Point'
-              coordinates: [-121.0123, 56.789]
+          description: A circular geographic shape on the surface of the earth.
+        outline_polygon:
+          anyOf:
+            - $ref: '#/components/schemas/Polygon'
+          description: A polygonal geographic shape on the surface of the earth.
         altitude_lower:
           description: Minimum bounding altitude of this volume.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Altitude'
         altitude_upper:
           description: Maximum bounding altitude of this volume.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Altitude'
 
     Volume4D:
@@ -400,11 +409,11 @@ components:
           $ref: '#/components/schemas/Volume3D'
         time_start:
           description: Beginning time of this volume.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Time'
         time_end:
           description: End time of this volume.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Time'
 
     ErrorResponse:
@@ -480,13 +489,13 @@ components:
           description: |-
             If set, this subscription will not receive notifications involving airspace changes
             entirely before this time.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Time'
         time_end:
           description: |-
             If set, this subscription will not receive notifications involving airspace changes
             entirely after this time.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Time'
         uss_base_url:
           $ref: '#/components/schemas/SubscriptionUssBaseURL'
@@ -586,7 +595,7 @@ components:
       description: |-
         The base URL of a USS implementation of the parts of the USS-USS API necessary for
         receiving the notifications requested by this Subscription.
-      allOf:
+      anyOf:
         - $ref: '#/components/schemas/UssBaseURL'
 
     PutSubscriptionResponse:
@@ -707,15 +716,15 @@ components:
             is owned by the USS retrieving or providing it.  Not populated when the
             OperationReference is not owned by the USS retrieving or providing it (instead, the
             USS must obtain the OVN from the details retrieved from the owning USS).
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/EntityOVN'
         time_start:
           description: Beginning time of Operation.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Time'
         time_end:
           description: End time of Operation.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Time'
         uss_base_url:
           $ref: '#/components/schemas/OperationUssBaseURL'
@@ -723,7 +732,7 @@ components:
           description: |-
             The ID of the Subscription that is ensuring the Operation owner receives relevant
             airspace updates.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/SubscriptionUUID'
 
     OperationUssBaseURL:
@@ -731,7 +740,7 @@ components:
         The base URL of a USS implementation that implements the parts of the USS-USS API necessary for
         providing the details of this Operation, and telemetry during non-conformance or contingency,
         if applicable.
-      allOf:
+      anyOf:
         - $ref: '#/components/schemas/UssBaseURL'
 
     PutOperationReferenceParameters:
@@ -771,7 +780,7 @@ components:
             OVNs for Constraints are required if and only if the USS owning this Operation is considering
             Constraints, which is determined by whether the Subscription associated with this Operation
             triggers notifications for Constraints.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Key'
         state:
           $ref: '#/components/schemas/OperationState'
@@ -784,7 +793,7 @@ components:
             `new_subscription` field must be provided in order to provide notification capability
             for the Operation.  The Subscription specified by this ID must cover at least the area over
             which this Operation is conducted, and it must provide notifications for Operations.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/EntityUUID'
         new_subscription:
           description: |-
@@ -792,7 +801,7 @@ components:
             populated.  When this field is populated, an implicit Subscription will be created and
             associated with this Operation, and will generally be deleted automatically upon the
             deletion of this Operation.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/ImplicitSubscriptionParameters'
 
     ImplicitSubscriptionParameters:
@@ -807,7 +816,7 @@ components:
             The base URL of a USS implementation of the parts of the USS-USS API necessary for
             receiving the notifications that the Operation must be aware of.  This includes, at least,
             notifications for relevant changes in Operations.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/SubscriptionUssBaseURL'
         notify_for_constraints:
           description: |-
@@ -907,7 +916,7 @@ components:
             is owned by the USS retrieving or providing it.  Not populated when the
             ConstraintReference is not owned by the USS retrieving or providing it (instead, the
             USS must obtain the OVN from the details retrieved from the owning USS).
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/EntityOVN'
         time_start:
           $ref: '#/components/schemas/Time'
@@ -920,7 +929,7 @@ components:
       description: |-
         The base URL of a USS implementation that implements the parts of the USS-USS API necessary for
         providing the details of this Constraint.
-      allOf:
+      anyOf:
         - $ref: '#/components/schemas/UssBaseURL'
 
     PutConstraintReferenceParameters:
@@ -1060,11 +1069,11 @@ components:
           description: Human-readable description of the problem with the response.
         time_request:
           description: The time at which the problematic request was initiated.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Time'
         time_response:
           description: The time at which the problematic response was received.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Time'
         report_id:
           description: ID assigned by the server receiving the report.  Not populated when submitting a report.
@@ -1120,7 +1129,7 @@ components:
       properties:
         operation_id:
           description: ID of Operation that has changed.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/EntityUUID'
         operation:
           description: |-
@@ -1128,7 +1137,7 @@ components:
             the Operation was deleted.  A newly-created Operation can be differentiated from
             an updated Operation by examining the `version` field.  The `ovn` field in the
             nested `reference` must be populated.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Operation'
         subscriptions:
           type: array
@@ -1188,7 +1197,7 @@ components:
       properties:
         constraint_id:
           description: ID of Constraint that has changed.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/EntityUUID'
         constraint:
           description: |-
@@ -1196,7 +1205,7 @@ components:
             the Constraint was deleted.  A newly-created Constraint can be differentiated from
             an updated Constraint by examining the `version` field.  The `ovn` field in the
             nested `reference` must be populated.
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Constraint'
         subscriptions:
           description: Subscription(s) prompting this notification.
@@ -1296,6 +1305,8 @@ components:
             True if this position was generated primarily by computation
             rather than primarily from a direct instrument measurement.
             Assumed false if not specified.
+          type: boolean
+          default: false
         altitude:
           $ref: '#/components/schemas/Altitude'
 
@@ -1341,6 +1352,7 @@ paths:
         required: true
       tags:
         - "Operation references"
+        - dss
       security:
         - Authority:
             - utm.strategic_coordination
@@ -1398,6 +1410,7 @@ paths:
     get:
       tags:
         - "Operation references"
+        - dss
       security:
         - Authority:
             - utm.strategic_coordination
@@ -1451,6 +1464,7 @@ paths:
         required: true
       tags:
         - "Operation references"
+        - dss
       security:
         - Authority:
             - utm.strategic_coordination
@@ -1515,6 +1529,7 @@ paths:
     delete:
       tags:
         - "Operation references"
+        - dss
       security:
         - Authority:
             - utm.strategic_coordination
@@ -1585,6 +1600,7 @@ paths:
         required: true
       tags:
         - "Constraint references"
+        - dss
       security:
         - Authority:
             - utm.constraint_management
@@ -1644,6 +1660,7 @@ paths:
     get:
       tags:
         - "Constraint references"
+        - dss
       security:
         - Authority:
             - utm.constraint_management
@@ -1699,6 +1716,7 @@ paths:
         required: true
       tags:
         - "Constraint references"
+        - dss
       security:
         - Authority:
             - utm.constraint_management
@@ -1762,6 +1780,7 @@ paths:
     delete:
       tags:
         - "Constraint references"
+        - dss
       security:
         - Authority:
             - utm.constraint_management
@@ -1831,6 +1850,7 @@ paths:
         required: true
       tags:
         - "Subscriptions"
+        - dss
       security:
         - Authority:
             - utm.constraint_consumption
@@ -1902,6 +1922,7 @@ paths:
     get:
       tags:
         - "Subscriptions"
+        - dss
       security:
         - Authority:
             - utm.constraint_consumption
@@ -1967,6 +1988,7 @@ paths:
         required: true
       tags:
         - "Subscriptions"
+        - dss
       responses:
         "200":
           content:
@@ -2026,6 +2048,7 @@ paths:
     delete:
       tags:
         - "Subscriptions"
+        - dss
       security:
         - Authority:
             - utm.constraint_consumption
@@ -2094,6 +2117,7 @@ paths:
         required: true
       tags:
         - "Reports"
+        - dss
       responses:
         "201":
           description: A new Report was created successfully (and archived).
@@ -2147,6 +2171,7 @@ paths:
     get:
       tags:
         - "Operation details"
+        - p2p_utm
       security:
         - Authority:
             - utm.strategic_coordination
@@ -2204,6 +2229,7 @@ paths:
     get:
       tags:
         - "Operation details"
+        - p2p_utm
       security:
         - Authority:
             - utm.strategic_coordination
@@ -2258,6 +2284,7 @@ paths:
     post:
       tags:
         - "Operation details"
+        - p2p_utm
       security:
         - Authority:
             - utm.strategic_coordination
@@ -2328,6 +2355,7 @@ paths:
     get:
       tags:
         - "Constraint details"
+        - p2p_utm
       security:
         - Authority:
             - utm.strategic_coordination
@@ -2380,6 +2408,7 @@ paths:
     post:
       tags:
         - "Constraint details"
+        - p2p_utm
       security:
         - Authority:
             - utm.strategic_coordination
@@ -2443,6 +2472,7 @@ paths:
     post:
       tags:
         - "Reports"
+        - p2p_utm
       security:
         - Authority:
             - utm.strategic_coordination


### PR DESCRIPTION
This PR adjusts the API to codegen more easily.  This includes:
* Changing allOf to anyOf; anyOf seems to be more well-supported (this also includes with ReDoc)
* Removing all oneOf's as most programming languages don't allow a field to be able to take on multiple types
  * `area` in Volume3D -> `outline_circle` + `outline_polygon`
  * LonLatPair.items -> LongitudeOrLatitude
* Adding `dss` and `p2p_utm` tags to indicate which parts of the API should be implemented by which kinds of systems
* Adding missing `type`s to some fields

I also fixed a reversed `minimum` and `maximum` on Longitude.

To see just the substantive changes apart from formatting being fixed, see just the second commit.