### PR TITLE
Add missing type to make openapi2proto

### DIFF
--- a/utm.yaml
+++ b/utm.yaml
@@ -1688,6 +1688,7 @@ components:
           description: |-
             A coded indication for the reason that led to the establishment of the zone.
           maxItems: 9
+          type: array
         other_reason_info:
           type: string
           maxLength: 30


### PR DESCRIPTION
Currently openapi2proto will fail when attempting to compile utm.yaml into scd.proto. The error is around a missing type in GeoZone/reason property.